### PR TITLE
Issue 3/correctly identifying the crc kind during the breakdown process

### DIFF
--- a/proptest-regressions/tx/breakdown.txt
+++ b/proptest-regressions/tx/breakdown.txt
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 13a27eb3f0b08e04447b7c3461b0f7807ed1e33e7f20d7abff0ad062c49c7a27 # shrinks to last_frame_data_len = 3
+cc 3bb381aa750235c5773b589f5066490036863bd0f78f200a244d57f469009611 # shrinks to last_frame_data_len = 1
+cc 47d4be3a452b7de85376d2fdcce3319f3bbfba8d9683fcf411639b486bff12a9 # shrinks to last_frame_data_len = 1

--- a/src/tx/breakdown.rs
+++ b/src/tx/breakdown.rs
@@ -41,19 +41,20 @@ pub enum CRCKind {
     Isolated,
 }
 
-fn crc_kind<const MTU: usize>(last_frame_data_len: usize) -> CRCKind {
+fn crc_kind<const MTU: usize>(payload_remainder: usize) -> CRCKind {
     // TODO: Cannot match here because of pattern restriction for constants and
     // expressions. There might be a way to do this remember to check when
     // possible.
-    let remaining_space = MTU - last_frame_data_len - 1;
-    if remaining_space == MTU - 1 {
+
+    let remaining_space = MTU - payload_remainder - 1;
+    if remaining_space == 0 || payload_remainder == 0 {
         CRCKind::Isolated
     } else if remaining_space == 1 {
         CRCKind::HalfEmbedded
-    } else if (2..=(MTU - 3)).contains(&remaining_space) {
+    } else if (2..=MTU).contains(&remaining_space) {
         CRCKind::Embedded
     } else {
-        panic!(
+        core::panic!(
             "CRCKind is unknown. This should not happen. \
             Are you sure that this function was called with \
             the length of the last data frame in the transfer?"


### PR DESCRIPTION
Resolves #3.

`crc_kind` was corrected to follow the specified behavior and some tests were added for it.

Furthermore, some documentation for `CRCKind` and `crc_kind` was added.