### PR TITLE
Aligns the tail byte tests to the specification.

### DIFF
--- a/src/tail_byte/tail_byte.rs
+++ b/src/tail_byte/tail_byte.rs
@@ -227,13 +227,12 @@ mod tests {
     }
 
     #[test]
-    fn the_successor_of_a_tail_byte_has_a_transfer_id_that_is_the_successor_of_the_transfer_id_of_the_original_tail_byte(
+    fn the_successor_of_a_tail_byte_has_the_same_transfer_id_as_the_original_tail_byte(
     ) {
         let mut tail_byte = TailByte::start_of_multi_frame(TransferId::try_from(0).unwrap());
         let mut original_transfer_id = tail_byte.transfer_id();
 
         tail_byte.advance();
-        original_transfer_id.advance();
 
         assert_eq!(tail_byte.transfer_id(), original_transfer_id);
     }


### PR DESCRIPTION
Resolves #8.

`the_successor_of_a_tail_byte_has_a_transfer_id_that_is_the_successor_of_the_transfer_id_of_the_original_tail_byte`
test was testing for a behavior that does not respect the uavcan specification.

This behavior is a refuse of a misunderstanding of the specification and an
incorrect implementation.

Indeed, transfer-ids are static during a multi-frame transfer.

The behavior was previously aligned with a corrected implementation but the test
was not changed, resulting in the incorrect behavior being tested and test
failing fallaciously.

The test is now aligned with the implementation and tests the correct behavior.