### PR TITLE
Fixes the embedding of the second byte of the crc in Breakdown

### DIFF
--- a/src/tx/breakdown.rs
+++ b/src/tx/breakdown.rs
@@ -242,7 +242,7 @@ impl<'a, Frame: CanFrame<MTU>, const MTU: usize> Breakdown<'a, Frame, MTU> {
 
         build_frame(
             self.can_id,
-            &self.crc.get_crc().to_be_bytes()[..1],
+            &self.crc.get_crc().to_be_bytes()[1..],
             self.tail_byte,
         )
     }


### PR DESCRIPTION
Resolves #13.

When the `HalfEmbedded` case of the crc is encountered during a `Breakdown`, the
first byte of the crc is expected to be the second to last byte of the
penultimate frame and the second byte is expected to be positioned as the first
byte of the frame that closes the transfer.

In `Breakdown`, this is managed in two stages, the first byte is written in
`build_multi_frame`, under the `None=>CRCKind::HalfEmbedded` case, while the
second byte is written in `build_half_crc`.

In the current implementation, when the positioning of the crc was correct, but
the first byte was written two times, such that the embedded crc was wrong,
resulting in an error in the `Buildup` process.

This was because the wrong byte of the crc was used in `build_half_crc`.

The behavior is now corrected and the correct byte of the crc is used in `build_half_crc`.