### PR TITLE
Issue 15/investigating session id try from implementation

### DIFF
--- a/src/rx/buildup.rs
+++ b/src/rx/buildup.rs
@@ -1,5 +1,5 @@
 use core::{
-    convert::{TryFrom, TryInto},
+    convert::TryInto,
     marker::PhantomData,
 };
 use crc_any::CRCu16;
@@ -69,7 +69,7 @@ impl<Frame: CanFrame<MTU>, Capacity: ArrayLength<u8>, const MTU: usize>
     }
 
     pub fn push(&mut self, frame: Frame) -> Result<BuildupState, Error<Frame, MTU>> {
-        let session_id = SessionId::try_from(frame.id()).map_err(|_| Error::CorruptedId)?;
+        let session_id = SessionId::from(frame.id());
         session_id
             .is_valid()
             .then(|| ())

--- a/src/session_id/session_id.rs
+++ b/src/session_id/session_id.rs
@@ -25,14 +25,21 @@ impl From<u32> for SessionId {
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-//     #[test]
-//     fn building_a_session_id_from_a_number_with_the_25th_bit_not_set_provides_a_message() {
-//         let id = SessionId::try_from(0u32).unwrap();
+    #[test]
+    fn a_can_id_with_the_26th_bit_not_set_is_a_message() {
+        let id = SessionId::from(0u32);
 
-//         assert!(matches!(id, SessionId::Message(_)))
-//     }
-// }
+        assert!(matches!(id, SessionId::Message(_)))
+    }
+
+    #[test]
+    fn a_can_id_with_the_26th_bit_set_is_an_rpc() {
+        let id = SessionId::from(1u32 << 25);
+
+        assert!(matches!(id, SessionId::Rpc(_)))
+    }
+}

--- a/src/session_id/session_id.rs
+++ b/src/session_id/session_id.rs
@@ -1,5 +1,4 @@
-use super::{error::InvalidRepresentation, message::MessageSessionId, service::ServiceSessionId};
-use core::convert::TryFrom;
+use super::{message::MessageSessionId, service::ServiceSessionId};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SessionId {
@@ -16,15 +15,12 @@ impl SessionId {
     }
 }
 
-impl TryFrom<u32> for SessionId {
-    type Error = InvalidRepresentation;
-
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        let is_service = (value >> 25) & 1;
-        match is_service {
-            0 => Ok(SessionId::Message(MessageSessionId::from(value))),
-            0 => Ok(SessionId::Rpc(ServiceSessionId::from(value))),
-            _ => panic!("Error in the bit pattern when converting a u32 to a session id. This shouldn't happen, a logic bug may be in place.")
+impl From<u32> for SessionId {
+    fn from(value: u32) -> Self {
+        if ((value >> 25) & 1) == 0 {
+            SessionId::Message(MessageSessionId::from(value))
+        } else {
+            SessionId::Rpc(ServiceSessionId::from(value))
         }
     }
 }


### PR DESCRIPTION
Resolves #15.

`SessionId` is converted from a u32, representing the can id of the passed in
frame, during the `Buildup` process.

The `uavcan::session_id::session_id` module provided an implementation of
`TryFrom<u32>` for this reason.

At the level of `SessionId`, currently albeit this may change, any 32 bit value
is considered correct as the only discriminant is the value of the 26th bit,
which is always either zero or one.

For this reason, the implementation of `TryFrom` had no sensible way to return
an error and was converted to a `From` implementation.

The `TryFrom` implementation was further wrongly implemented, considering a
0-valued 26th bit both a message and a service, creating an unreachable branch,
and providing a defensive panic, which should have been unreachable, if this was
the case.

The new `From` implementation corrects the incorrect behavior and simplifies the
implementation.

The call to `SessionId::try_from` in `Buildup` was modified to call the new
`From` implementation.

Tests for the `From` implementation were added to `uavcan::session_id::session_id`.