### PR TITLE
Hides dev-dependencies behind a target flag.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,15 @@ name = "uavcan"
 version = "0.1.0"
 authors = ["Di Sera Luca <disera.luca@gmail.com>"]
 edition = "2018"
+resolver = "2"
 
 [dependencies]
 modular-bitfield = "0.11"
 heapless = "0.6"
 crc-any = { version = "2.3", default-features = false }
 
-[dev-dependencies]
+[target.'cfg(any(windows, unix))'.dev-dependencies]
 socketcan = "1.7"
 rand = "0.8"
 proptest = "1.0"
+


### PR DESCRIPTION
Resolves #21.

Cargo build, normally, downloads and compiles all dependencies independently of
if they are needed or not.

In the case of uavcan, this means that dev-dependencies, which depend on std and
are used only for tests and examples, are downloaded even when building only the
library targeting an embedded device, where std is not available, failing the
compilation.

To avoid this issue, all std-based dev-dependencies are now hidden behind a
target flag that comprises the general mainstream OSes.

Furthermore, the resolver for cargo is now set to default to the second version
to avoid downloading dependencies that are needed on specific platforms only
when building for a different target.
See
https://doc.rust-lang.org/cargo/reference/features.html#feature-resolver-version-2
for an explanation.