### PR TITLE
Issue 6/adding the no std attribute to the crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 pub mod rx;
 pub mod session_id;
 pub mod tail_byte;

--- a/src/tx/breakdown.rs
+++ b/src/tx/breakdown.rs
@@ -277,7 +277,9 @@ impl<'a, Frame: CanFrame<MTU>, const MTU: usize> Iterator for Breakdown<'a, Fram
 mod tests {
     use super::*;
     use proptest::prelude::*;
+
     extern crate std;
+    use std::format;
 
     use crate::CLASSIC_MTU;
 


### PR DESCRIPTION
Resolves #6.

* Proptest requires std::format to work correctly.

  Since the crate is intended to be #![no_std], std is not externed by default and
  its prelude is not being imported.

  Since the prelude is not automatically imported, `std::format` is not available
  for those tests that requires it even when `std` is externed.

  The tests in `breakdown.rs` use proptest and require it, otherwise cargo test
  will not be able to build correctly.

  For this reason, `std::format` was added as an import in `breakdown.rs`' tests module.
* Adds the #![no_std] attribute to the crate.
