### PR TITLE
Issue 10/correcting compilation warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 resolver = "2"
 
 [dependencies]
-modular-bitfield = "0.11"
+modular-bitfield = { git = "https://github.com/diseraluca/modular-bitfield" }
 heapless = "0.6"
 crc-any = { version = "2.3", default-features = false }
 

--- a/src/session_id/message.rs
+++ b/src/session_id/message.rs
@@ -10,12 +10,17 @@ pub struct MessageSessionId {
     reserved7: B1,
     #[bits = 13]
     pub subject_id: SubjectId,
+    #[skip(getters)]
     reserved21: B1,
+    #[skip(getters)]
     reserved22: B1,
+    #[skip(setters)]
     reserved23: B1,
+    #[skip(getters)]
     is_anonymous: bool,
     pub is_service: bool,
     #[bits = 3]
+    #[skip(getters)]
     priority: TransferPriority,
     #[skip]
     __: B3,

--- a/src/session_id/node_id.rs
+++ b/src/session_id/node_id.rs
@@ -5,6 +5,7 @@ use modular_bitfield::prelude::*;
 #[bitfield(bits = 7)]
 #[derive(BitfieldSpecifier, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NodeId {
+    #[skip(getters)]
     id: B7,
 }
 

--- a/src/session_id/service.rs
+++ b/src/session_id/service.rs
@@ -13,8 +13,10 @@ pub struct ServiceSessionId {
     pub service_id: ServiceId,
     reserved23: B1,
     pub is_request: bool,
+    #[skip(getters)]
     is_service: bool,
     #[bits = 3]
+    #[skip(getters)]
     priority: TransferPriority,
     #[skip]
     __: B3,

--- a/src/session_id/service_id.rs
+++ b/src/session_id/service_id.rs
@@ -5,6 +5,7 @@ use modular_bitfield::prelude::*;
 #[bitfield(bits = 9)]
 #[derive(BitfieldSpecifier, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ServiceId {
+    #[skip(getters)]
     id: B9,
 }
 

--- a/src/session_id/subject_id.rs
+++ b/src/session_id/subject_id.rs
@@ -5,6 +5,7 @@ use modular_bitfield::prelude::*;
 #[bitfield(bits = 13)]
 #[derive(BitfieldSpecifier, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct SubjectId {
+    #[skip(getters)]
     id: B13,
 }
 


### PR DESCRIPTION
Resolves #10.

- The modular bitfield crate produces an unneccesary braces warning when `From`
implementations are generated.

  See: Robbepop/modular-bitfield#66

  A pull request ( Robbepop/modular-bitfield#68 ) to
  resolve this was provided.

  Since it is not yet accepted mainstream, the `modular-bitfield` dependency was
  temporarily moved to a custom fork to move forward with the removal of
  compilation warnings.

- Previously, `Buildup` calculated the crc by digesting data as it was used.
For this reason, it contained a crc field to keep track of it.

  This was later changed to reduce the state that was kept during a `Buildup`,
  calculating it in place when the last frame of a transfer and its crc are met.

  The previous code was only commented out and the field containing the crc was
  kept, producing a dead code warning.

  The `crc` field is now removed from `Buildup`, and the commented code that
  referred to it was removed.

- The `modular-bitfield` crate, by default, generates a series of getters and
setters method for each field.

  When those are unused, a dead code warning is produced.

  To avoid the warnings, appropriate `#[skip]` attributes for the field of
  various structures were added.