### PR TITLE
Issue 25/avoiding the missing generation of getters for the test build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![feature(cfg_eval)]
 
 pub mod rx;
 pub mod session_id;

--- a/src/session_id/message.rs
+++ b/src/session_id/message.rs
@@ -1,6 +1,7 @@
 use super::{node_id::NodeId, subject_id::SubjectId, transfer_priority::TransferPriority};
 use modular_bitfield::prelude::*;
 
+#[cfg_eval]
 #[bitfield]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -20,7 +21,7 @@ pub struct MessageSessionId {
     is_anonymous: bool,
     pub is_service: bool,
     #[bits = 3]
-    #[skip(getters)]
+    #[cfg_attr(not(test), skip(getters))]
     priority: TransferPriority,
     #[skip]
     __: B3,

--- a/src/tail_byte/tail_byte.rs
+++ b/src/tail_byte/tail_byte.rs
@@ -230,7 +230,7 @@ mod tests {
     fn the_successor_of_a_tail_byte_has_the_same_transfer_id_as_the_original_tail_byte(
     ) {
         let mut tail_byte = TailByte::start_of_multi_frame(TransferId::try_from(0).unwrap());
-        let mut original_transfer_id = tail_byte.transfer_id();
+        let original_transfer_id = tail_byte.transfer_id();
 
         tail_byte.advance();
 


### PR DESCRIPTION
Resolves #25.

Recently, the getters for the priority field in
`uavcan::session_id::message::MessageSessionId` were disabled from being
generated to avoid an unused warning, as they are, indeed, unused in the build
codebase.

Nonetheless, the getter for `priority` is actually used by one of the tests, such
that is needed, but only when testing.

The general way to do this, would be to add a `#[cfg_attr(...)]` for the `skip`
attribute to avoid generating it during testing.

Unfortunately, `cfg*` attributes are not expanded before `proc_macro_attributes`
expansion and the `modular-bitfield` does not manage them manually.

This is a general problem in the proc-macro environment, with an example being
taiki-e/pin-project#68.

The rust team is working on a solution to this, see, for example:

https://doc.rust-lang.org/beta/unstable-book/library-features/cfg-eval.html
https://doc.rust-lang.org/beta/unstable-book/language-features/macro-attributes-in-derive-output.html

And the related issues.

In particular, `cfg_eval` provides a way to ensure that the `cfg` attributes are
evaluated before the expansion of the following macros.

For this reason, the `cfg_eval` was activated, a `#[cfg_eval]` attribute was
added to `MessageSessionId` and a `cfg_attr` conditioned on `test` was added to
the priority field of the same structure.

As this is not yet stabilized, the crate now depends on nightly, and cannot be
compiled in stable.

It was possible to provide workarounds to avoid moving outside stable.
For example, by duplicating `MessageSessionsId` and providing a version with the
`skip` attribute and one without, conditioning the whole structure, instead of a
field attribute, on `test`.

Nonetheless, being nightly only is not considered a problem for this crate
usage and the "forward-correct" solution was thus preferred.

- A unused mut in the tests that escaped #10 was removed.