### PR TITLE
Moves noop_method_call from allow to deny.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![feature(cfg_eval)]
+#![deny(noop_method_call)]
 
 pub mod rx;
 pub mod session_id;


### PR DESCRIPTION
Resolve #32.

Sets the `deny(noop_method_call)` attribute for the crate.