### PR TITLE
Moves single_use_lifetimes from allow to deny.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![feature(cfg_eval)]
-#![deny(noop_method_call)]
+#![deny(noop_method_call, single_use_lifetimes)]
 
 pub mod rx;
 pub mod session_id;
@@ -72,12 +72,11 @@ mod tests {
     }
 
     impl<
-            'a,
         Frame: CanFrame<MTU>,
         Capacity: ArrayLength<Transfer<TransferCapacity>>,
         TransferCapacity: ArrayLength<u8>,
         const MTU: usize,
-        > CanWriter<Frame, MTU> for TxRxGlue<'a, Frame, Capacity, TransferCapacity, MTU>
+        > CanWriter<Frame, MTU> for TxRxGlue<'_, Frame, Capacity, TransferCapacity, MTU>
     {
         type Error = RxError<Frame, MTU>;
 

--- a/src/rx/rx_network.rs
+++ b/src/rx/rx_network.rs
@@ -82,12 +82,11 @@ impl<
 }
 
 impl<
-        'a,
         Frame: CanFrame<MTU>,
         Capacity: ArrayLength<Transfer<TransferCapacity>>,
         TransferCapacity: ArrayLength<u8>,
         const MTU: usize,
-    > Iterator for RxConsumer<'a, Frame, Capacity, TransferCapacity, MTU>
+    > Iterator for RxConsumer<'_, Frame, Capacity, TransferCapacity, MTU>
 {
     type Item = Transfer<TransferCapacity>;
 
@@ -97,12 +96,11 @@ impl<
 }
 
 impl<
-        'a,
         Frame: CanFrame<MTU>,
         Capacity: ArrayLength<Transfer<TransferCapacity>>,
         TransferCapacity: ArrayLength<u8>,
         const MTU: usize,
-    > RxProducer<'a, Frame, Capacity, TransferCapacity, MTU>
+    > RxProducer<'_, Frame, Capacity, TransferCapacity, MTU>
 {
     pub fn receive(&mut self, frame: Frame) -> Result<(), RxError<Frame, MTU>> {
         // println!("Received frame {:?}", frame);

--- a/src/tx/breakdown.rs
+++ b/src/tx/breakdown.rs
@@ -260,7 +260,7 @@ impl<'a, Frame: CanFrame<MTU>, const MTU: usize> Breakdown<'a, Frame, MTU> {
     }
 }
 
-impl<'a, Frame: CanFrame<MTU>, const MTU: usize> Iterator for Breakdown<'a, Frame, MTU> {
+impl<Frame: CanFrame<MTU>, const MTU: usize> Iterator for Breakdown<'_, Frame, MTU> {
     type Item = Frame;
 
     fn next(&mut self) -> Option<Self::Item> {


### PR DESCRIPTION
Resolves #33.

Sets the `deny(single_use_lifetimes)` attribute for the crate.
