### PR TITLE
Issue 36/denying unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![feature(cfg_eval)]
-#![deny(noop_method_call, single_use_lifetimes, unreachable_pub)]
+#![deny(noop_method_call, single_use_lifetimes, unreachable_pub, unsafe_code)]
 
 pub mod rx;
 pub mod session_id;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![feature(cfg_eval)]
-#![deny(noop_method_call, single_use_lifetimes, unreachable_pub, unsafe_code)]
+#![deny(noop_method_call, single_use_lifetimes, unreachable_pub, unsafe_code, unsafe_op_in_unsafe_fn)]
 
 pub mod rx;
 pub mod session_id;


### PR DESCRIPTION
Resolves #36.

Sets the `deny(unsafe_code)` and `deny(unsafe_op_in_unsafe_fn)` attributes for the crate.