### PR TITLE
Moves unused_lifetimes from allow to deny.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![feature(cfg_eval)]
-#![deny(noop_method_call, single_use_lifetimes, unreachable_pub, unsafe_code, unsafe_op_in_unsafe_fn, unused_import_braces)]
+#![deny(noop_method_call, single_use_lifetimes, unreachable_pub, unsafe_code, unsafe_op_in_unsafe_fn, unused_import_braces, unused_lifetimes)]
 
 pub mod rx;
 pub mod session_id;


### PR DESCRIPTION
Resolves #38.

Sets the `deny(unused_lifetimes)` attribute for the crate.