### PR TITLE
Moves incomplete_features from warn to allow.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
+#![allow(incomplete_features)]
+#![deny(noop_method_call, single_use_lifetimes, unreachable_pub, unsafe_code, unsafe_op_in_unsafe_fn, unused_import_braces, unused_lifetimes)]
+
 #![no_std]
 #![feature(cfg_eval)]
-#![deny(noop_method_call, single_use_lifetimes, unreachable_pub, unsafe_code, unsafe_op_in_unsafe_fn, unused_import_braces, unused_lifetimes)]
 
 pub mod rx;
 pub mod session_id;


### PR DESCRIPTION
Resolves #42.

Sets the allow(incomplete_features) attribute for the crate.