### PR TITLE
Issue 27/configuring lint levels

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![feature(cfg_eval)]
-#![deny(noop_method_call, single_use_lifetimes, unreachable_pub, unsafe_code, unsafe_op_in_unsafe_fn, unused_import_braces)]
+#![deny(noop_method_call, single_use_lifetimes, unreachable_pub, unsafe_code, unsafe_op_in_unsafe_fn, unused_import_braces, unused_lifetimes)]
 
 pub mod rx;
 pub mod session_id;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(incomplete_features)]
-#![deny(noop_method_call, single_use_lifetimes, unreachable_pub, unsafe_code, unsafe_op_in_unsafe_fn, unused_import_braces, unused_lifetimes)]
+#![deny(noop_method_call, single_use_lifetimes, unreachable_pub, unsafe_code, unsafe_op_in_unsafe_fn, unused_import_braces, unused_lifetimes, warnings)]
 
 #![no_std]
 #![feature(cfg_eval)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![feature(cfg_eval)]
-#![deny(noop_method_call, single_use_lifetimes)]
+#![deny(noop_method_call, single_use_lifetimes, unreachable_pub)]
 
 pub mod rx;
 pub mod session_id;
@@ -39,7 +39,7 @@ mod tests {
     use std::format;
 
     #[derive(Debug)]
-    pub struct ClassicFrame {
+    pub(super) struct ClassicFrame {
         data: [u8; 8],
         id: u32,
         len: usize,
@@ -61,14 +61,14 @@ mod tests {
         }
     }
 
-    pub struct TxRxGlue<
+    pub(super) struct TxRxGlue<
             'a,
         Frame: CanFrame<MTU>,
         Capacity: ArrayLength<Transfer<TransferCapacity>>,
         TransferCapacity: ArrayLength<u8>,
         const MTU: usize,
         > {
-        pub rx_producer: RxProducer<'a, Frame, Capacity, TransferCapacity, MTU>,
+        pub(super) rx_producer: RxProducer<'a, Frame, Capacity, TransferCapacity, MTU>,
     }
 
     impl<

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![feature(cfg_eval)]
-#![deny(noop_method_call, single_use_lifetimes, unreachable_pub)]
+#![deny(noop_method_call, single_use_lifetimes, unreachable_pub, unsafe_code)]
 
 pub mod rx;
 pub mod session_id;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![feature(cfg_eval)]
-#![deny(noop_method_call, single_use_lifetimes, unreachable_pub, unsafe_code, unsafe_op_in_unsafe_fn)]
+#![deny(noop_method_call, single_use_lifetimes, unreachable_pub, unsafe_code, unsafe_op_in_unsafe_fn, unused_import_braces)]
 
 pub mod rx;
 pub mod session_id;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![feature(cfg_eval)]
-#![deny(noop_method_call, single_use_lifetimes, unreachable_pub, unsafe_code)]
+#![deny(noop_method_call, single_use_lifetimes, unreachable_pub, unsafe_code, unsafe_op_in_unsafe_fn)]
 
 pub mod rx;
 pub mod session_id;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![feature(cfg_eval)]
+#![deny(noop_method_call)]
 
 pub mod rx;
 pub mod session_id;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
+#![allow(incomplete_features)]
+#![deny(noop_method_call, single_use_lifetimes, unreachable_pub, unsafe_code, unsafe_op_in_unsafe_fn, unused_import_braces, unused_lifetimes)]
+
 #![no_std]
 #![feature(cfg_eval)]
-#![deny(noop_method_call, single_use_lifetimes, unreachable_pub, unsafe_code, unsafe_op_in_unsafe_fn, unused_import_braces, unused_lifetimes)]
 
 pub mod rx;
 pub mod session_id;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![feature(cfg_eval)]
-#![deny(noop_method_call)]
+#![deny(noop_method_call, single_use_lifetimes)]
 
 pub mod rx;
 pub mod session_id;
@@ -72,12 +72,11 @@ mod tests {
     }
 
     impl<
-            'a,
         Frame: CanFrame<MTU>,
         Capacity: ArrayLength<Transfer<TransferCapacity>>,
         TransferCapacity: ArrayLength<u8>,
         const MTU: usize,
-        > CanWriter<Frame, MTU> for TxRxGlue<'a, Frame, Capacity, TransferCapacity, MTU>
+        > CanWriter<Frame, MTU> for TxRxGlue<'_, Frame, Capacity, TransferCapacity, MTU>
     {
         type Error = RxError<Frame, MTU>;
 

--- a/src/rx/rx_network.rs
+++ b/src/rx/rx_network.rs
@@ -82,12 +82,11 @@ impl<
 }
 
 impl<
-        'a,
         Frame: CanFrame<MTU>,
         Capacity: ArrayLength<Transfer<TransferCapacity>>,
         TransferCapacity: ArrayLength<u8>,
         const MTU: usize,
-    > Iterator for RxConsumer<'a, Frame, Capacity, TransferCapacity, MTU>
+    > Iterator for RxConsumer<'_, Frame, Capacity, TransferCapacity, MTU>
 {
     type Item = Transfer<TransferCapacity>;
 
@@ -97,12 +96,11 @@ impl<
 }
 
 impl<
-        'a,
         Frame: CanFrame<MTU>,
         Capacity: ArrayLength<Transfer<TransferCapacity>>,
         TransferCapacity: ArrayLength<u8>,
         const MTU: usize,
-    > RxProducer<'a, Frame, Capacity, TransferCapacity, MTU>
+    > RxProducer<'_, Frame, Capacity, TransferCapacity, MTU>
 {
     pub fn receive(&mut self, frame: Frame) -> Result<(), RxError<Frame, MTU>> {
         // println!("Received frame {:?}", frame);

--- a/src/tx/breakdown.rs
+++ b/src/tx/breakdown.rs
@@ -260,7 +260,7 @@ impl<'a, Frame: CanFrame<MTU>, const MTU: usize> Breakdown<'a, Frame, MTU> {
     }
 }
 
-impl<'a, Frame: CanFrame<MTU>, const MTU: usize> Iterator for Breakdown<'a, Frame, MTU> {
+impl<Frame: CanFrame<MTU>, const MTU: usize> Iterator for Breakdown<'_, Frame, MTU> {
     type Item = Frame;
 
     fn next(&mut self) -> Option<Self::Item> {


### PR DESCRIPTION
Resolves #27.

Resolves #32, Resolves #33, Resolves #35, Resolves #36, Resolves #37, Resolves #38, Resolves #42, Resolves #43. 

- Moves noop_method_call from allow to deny.
- Moves single_use_lifetimes from allow to deny.
- Moves unreachable_pub from allow to deny.
- Moves unsafe_code from allow to deny.
- Moves unsafe-op-in-unsafe-code from allow to deny.
- Moves unused_import_braces from allow to deny.
- Moves unused_lifetimes from allow to deny.
- Moves incomplete_features from warn to allow.
- Denies all warnings in the crate.

- All code that was invalidated by the changes was corrected to be aligned to the new guidelines.

#30 remains to be completed. As it depends on #31, which might require a lot of time, it will be completed on its own and not as part of this merge request and #27.
