### PR TITLE
Issue 55/configuring clippy and aligning the codebase to it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 resolver = "2"
 
 [dependencies]
-modular-bitfield = { git = "https://github.com/diseraluca/modular-bitfield", branch = "removes_the_unneccesary_braces_in_from_implementations"}
+modular-bitfield = { git = "https://github.com/diseraluca/modular-bitfield" }
 heapless = "0.6"
 crc-any = { version = "2.3", default-features = false }
 

--- a/examples/hello_can.rs
+++ b/examples/hello_can.rs
@@ -58,7 +58,7 @@ impl CanWriter<ClassicFrame, CLASSIC_MTU> for CanTx {
 fn transmit(
     transmitter: &mut StreamTransmitter<CanTx, ClassicFrame, CLASSIC_MTU>,
     node_id: NodeId,
-) -> () {
+) {
     println!("Building random payload for transmission.");
     let mut payload = [0u8; 64];
     rand::thread_rng().fill_bytes(&mut payload);
@@ -81,7 +81,7 @@ fn transmit(
 fn receive<'a>(
     rx_socket: &CANSocket,
     receiver: &mut RxProducer<'a, ClassicFrame, U64, U512, CLASSIC_MTU>,
-) -> () {
+) {
     println!("Looking for frames from socket.");
     while let Ok(frame) = rx_socket.read_frame() {
         println!("Found frame {:?}.", frame);
@@ -91,7 +91,7 @@ fn receive<'a>(
     }
 }
 
-fn process<'a>(receiver: &mut RxConsumer<'a, ClassicFrame, U64, U512, CLASSIC_MTU>) -> () {
+fn process<'a>(receiver: &mut RxConsumer<'a, ClassicFrame, U64, U512, CLASSIC_MTU>) {
     println!("Looking for stored transfers.");
     while let Some(transfer) = receiver.next() {
         println!("Found transfer {:?}", transfer);

--- a/examples/hello_can.rs
+++ b/examples/hello_can.rs
@@ -93,7 +93,7 @@ fn receive<'a>(
 
 fn process(receiver: &mut RxConsumer<ClassicFrame, U64, U512, CLASSIC_MTU>) {
     println!("Looking for stored transfers.");
-    while let Some(transfer) = receiver.next() {
+    for transfer in receiver {
         println!("Found transfer {:?}", transfer);
     }
 }

--- a/examples/hello_can.rs
+++ b/examples/hello_can.rs
@@ -113,7 +113,7 @@ fn main() {
     println!("Transmitter initialized.");
 
     println!("Initializing receiver network.");
-    let mut rx_network = RxNetwork::<ClassicFrame, U64, U512, CLASSIC_MTU>::new();
+    let mut rx_network = RxNetwork::<ClassicFrame, U64, U512, CLASSIC_MTU>::default();
     let (mut rx_producer, mut rx_consumer) = rx_network.split();
     println!("Receiver network initialized.");
 

--- a/examples/hello_can.rs
+++ b/examples/hello_can.rs
@@ -91,7 +91,7 @@ fn receive<'a>(
     }
 }
 
-fn process<'a>(receiver: &mut RxConsumer<'a, ClassicFrame, U64, U512, CLASSIC_MTU>) {
+fn process(receiver: &mut RxConsumer<ClassicFrame, U64, U512, CLASSIC_MTU>) {
     println!("Looking for stored transfers.");
     while let Some(transfer) = receiver.next() {
         println!("Found transfer {:?}", transfer);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(incomplete_features)]
+#![allow(incomplete_features, clippy::module_inception)]
 #![deny(
     noop_method_call,
     single_use_lifetimes,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ mod tests {
     proptest! {
         #[test]
         fn receiving_the_frames_of_a_transmission_rebuilds_the_original_payload(payload in vec(proptest::num::u8::ANY, 1..100)) {
-            let mut rx_network = RxNetwork::<ClassicFrame, U64, U512, CLASSIC_MTU>::new();
+            let mut rx_network = RxNetwork::<ClassicFrame, U64, U512, CLASSIC_MTU>::default();
             let (rx_producer, mut rx_consumer) = rx_network.split();
 
             let mut transmitter = StreamTransmitter::<TxRxGlue<ClassicFrame, U64, U512, CLASSIC_MTU>, ClassicFrame, CLASSIC_MTU>::new(TxRxGlue{ rx_producer });
@@ -134,7 +134,7 @@ mod tests {
     proptest! {
         #[test]
         fn receiving_the_frames_of_a_transmission_rebuilds_the_original_session_kind(payload in vec(proptest::num::u8::ANY, 1..100), kind in session_kind()) {
-            let mut rx_network = RxNetwork::<ClassicFrame, U64, U512, CLASSIC_MTU>::new();
+            let mut rx_network = RxNetwork::<ClassicFrame, U64, U512, CLASSIC_MTU>::default();
             let (rx_producer, mut rx_consumer) = rx_network.split();
 
             let mut transmitter = StreamTransmitter::<TxRxGlue<ClassicFrame, U64, U512, CLASSIC_MTU>, ClassicFrame, CLASSIC_MTU>::new(TxRxGlue{ rx_producer });

--- a/src/rx/buildup.rs
+++ b/src/rx/buildup.rs
@@ -176,9 +176,9 @@ impl<Frame: CanFrame<MTU>, Capacity: ArrayLength<u8>, const MTU: usize>
     fn ensure_no_missing_frames(&self, transfer_id: TransferId) -> Result<(), Error<Frame, MTU>> {
         (self.tail_byte.get_transfer_id() == transfer_id)
             .then(|| ())
-            .ok_or(Error::MissingFrames(
-                self.tail_byte.get_transfer_id().difference(transfer_id),
-            ))
+            .ok_or_else(|| {
+                Error::MissingFrames(self.tail_byte.get_transfer_id().difference(transfer_id))
+            })
     }
 
     fn ensure_tail_byte(&self, tail_byte: TailByte) -> Result<(), Error<Frame, MTU>> {
@@ -199,7 +199,7 @@ impl<Frame: CanFrame<MTU>, Capacity: ArrayLength<u8>, const MTU: usize>
 
         (own_crc.get_crc() == crc)
             .then(|| ())
-            .ok_or(Error::WrongCRC(own_crc.get_crc(), crc))
+            .ok_or_else(|| Error::WrongCRC(own_crc.get_crc(), crc))
     }
 }
 

--- a/src/rx/buildup.rs
+++ b/src/rx/buildup.rs
@@ -47,10 +47,10 @@ pub struct Buildup<Frame: CanFrame<MTU>, Capacity: ArrayLength<u8>, const MTU: u
     _frame_marker: PhantomData<Frame>,
 }
 
-impl<Frame: CanFrame<MTU>, Capacity: ArrayLength<u8>, const MTU: usize>
-    Buildup<Frame, Capacity, MTU>
+impl<Frame: CanFrame<MTU>, Capacity: ArrayLength<u8>, const MTU: usize> Default
+    for Buildup<Frame, Capacity, MTU>
 {
-    pub fn new() -> Self {
+    fn default() -> Self {
         Self {
             payload: Vec::new(),
             // TODO: Apart from documenting this the unintuitiveness of this
@@ -62,7 +62,11 @@ impl<Frame: CanFrame<MTU>, Capacity: ArrayLength<u8>, const MTU: usize>
             _frame_marker: PhantomData,
         }
     }
+}
 
+impl<Frame: CanFrame<MTU>, Capacity: ArrayLength<u8>, const MTU: usize>
+    Buildup<Frame, Capacity, MTU>
+{
     pub fn push(&mut self, frame: Frame) -> Result<BuildupState, Error<Frame, MTU>> {
         let session_id = SessionId::from(frame.id());
         session_id

--- a/src/rx/rx_network.rs
+++ b/src/rx/rx_network.rs
@@ -51,15 +51,23 @@ impl<
         Capacity: ArrayLength<Transfer<TransferCapacity>>,
         TransferCapacity: ArrayLength<u8>,
         const MTU: usize,
-    > RxNetwork<Frame, Capacity, TransferCapacity, MTU>
+    > Default for RxNetwork<Frame, Capacity, TransferCapacity, MTU>
 {
-    pub fn new() -> Self {
+    fn default() -> Self {
         Self {
             queue: Queue::new(),
             _frame_marker: PhantomData,
         }
     }
+}
 
+impl<
+        Frame: CanFrame<MTU>,
+        Capacity: ArrayLength<Transfer<TransferCapacity>>,
+        TransferCapacity: ArrayLength<u8>,
+        const MTU: usize,
+    > RxNetwork<Frame, Capacity, TransferCapacity, MTU>
+{
     pub fn split<'a>(
         &'a mut self,
     ) -> (
@@ -106,7 +114,7 @@ impl<
         // println!("Received frame {:?}", frame);
         match self
             .buildup
-            .get_or_insert_with(|| Buildup::new())
+            .get_or_insert_with(|| Buildup::default())
             .push(frame)
         {
             Ok(BuildupState::Closed) => self

--- a/src/rx/rx_network.rs
+++ b/src/rx/rx_network.rs
@@ -114,7 +114,7 @@ impl<
         // println!("Received frame {:?}", frame);
         match self
             .buildup
-            .get_or_insert_with(|| Buildup::default())
+            .get_or_insert_with(Buildup::default)
             .push(frame)
         {
             Ok(BuildupState::Closed) => self

--- a/src/rx/rx_network.rs
+++ b/src/rx/rx_network.rs
@@ -68,11 +68,11 @@ impl<
         const MTU: usize,
     > RxNetwork<Frame, Capacity, TransferCapacity, MTU>
 {
-    pub fn split<'a>(
-        &'a mut self,
+    pub fn split(
+        &mut self,
     ) -> (
-        RxProducer<'a, Frame, Capacity, TransferCapacity, MTU>,
-        RxConsumer<'a, Frame, Capacity, TransferCapacity, MTU>,
+        RxProducer<Frame, Capacity, TransferCapacity, MTU>,
+        RxConsumer<Frame, Capacity, TransferCapacity, MTU>,
     ) {
         let (producer, consumer) = self.queue.split();
 

--- a/src/session_id/message.rs
+++ b/src/session_id/message.rs
@@ -28,11 +28,11 @@ pub struct MessageSessionId {
 }
 
 impl MessageSessionId {
-    pub fn as_u32(
+    pub fn from_base_parts(
         source_node_id: NodeId,
         subject_id: SubjectId,
         priority: TransferPriority,
-    ) -> u32 {
+    ) -> Self {
         MessageSessionId::new()
             .with_source_node_id(source_node_id)
             .with_subject_id(subject_id)
@@ -41,7 +41,6 @@ impl MessageSessionId {
             .with_is_anonymous(false)
             .with_is_service(false)
             .with_priority(priority)
-            .into()
     }
 
     pub fn is_valid(&self) -> bool {
@@ -59,7 +58,7 @@ pub mod strategy {
 
     prop_compose! {
         pub fn message_session_id_as_u32()(source_node_id in node_id(), subject_id in subject_id(), transfer_priority in transfer_priority()) -> u32 {
-            MessageSessionId::as_u32(source_node_id, subject_id, transfer_priority)
+            MessageSessionId::from_base_parts(source_node_id, subject_id, transfer_priority).into()
         }
     }
 }
@@ -80,7 +79,7 @@ mod tests {
     proptest! {
         #[test]
         fn a_message_session_id_has_its_27th_to_29th_bit_represent_the_transfer_priority(transfer_priority in transfer_priority()) {
-            let id = MessageSessionId::as_u32(NodeId::try_from(4).unwrap(), SubjectId::try_from(8).unwrap(), transfer_priority);
+            let id = u32::from(MessageSessionId::from_base_parts(NodeId::try_from(4).unwrap(), SubjectId::try_from(8).unwrap(), transfer_priority));
             prop_assert_eq!(TransferPriority::try_from(((id >> 26) & 7)as u8).unwrap(), transfer_priority);
         }
     }
@@ -116,7 +115,7 @@ mod tests {
     proptest! {
         #[test]
         fn a_message_session_id_has_its_9th_to_21st_bit_represent_the_subject_id(subject_id in subject_id()) {
-            let id = MessageSessionId::as_u32(NodeId::try_from(4).unwrap(), subject_id, TransferPriority::Immediate);
+            let id = u32::from(MessageSessionId::from_base_parts(NodeId::try_from(4).unwrap(), subject_id, TransferPriority::Immediate));
             prop_assert_eq!(SubjectId::try_from(((id >> 8) & 8191) as u16).unwrap(), subject_id);
         }
     }
@@ -131,7 +130,7 @@ mod tests {
     proptest! {
         #[test]
         fn a_message_session_id_has_its_first_7_bits_represent_the_node_id(node_id in node_id()) {
-            let id = MessageSessionId::as_u32(node_id, SubjectId::try_from(4).unwrap(), TransferPriority::Immediate);
+            let id = u32::from(MessageSessionId::from_base_parts(node_id, SubjectId::try_from(4).unwrap(), TransferPriority::Immediate));
             prop_assert_eq!(NodeId::try_from((id & 127) as u8).unwrap(), node_id);
         }
     }
@@ -142,7 +141,7 @@ mod tests {
             let subject_id = SubjectId::new();
             let transfer_priority = TransferPriority::High;
 
-            let as_u32 = MessageSessionId::as_u32(source_node_id, subject_id, transfer_priority);
+            let as_u32 = u32::from(MessageSessionId::from_base_parts(source_node_id, subject_id, transfer_priority));
             let message_session_id = MessageSessionId::from(as_u32);
 
             prop_assert_eq!(message_session_id.source_node_id(), source_node_id);
@@ -155,7 +154,7 @@ mod tests {
             let source_node_id = NodeId::new();
             let transfer_priority = TransferPriority::High;
 
-            let as_u32 = MessageSessionId::as_u32(source_node_id, subject_id, transfer_priority);
+            let as_u32 = u32::from(MessageSessionId::from_base_parts(source_node_id, subject_id, transfer_priority));
             let message_session_id = MessageSessionId::from(as_u32);
 
             prop_assert_eq!(message_session_id.subject_id(), subject_id);
@@ -168,7 +167,7 @@ mod tests {
             let source_node_id = NodeId::new();
             let subject_id = SubjectId::new();
 
-            let as_u32 = MessageSessionId::as_u32(source_node_id, subject_id, transfer_priority);
+            let as_u32 = u32::from(MessageSessionId::from_base_parts(source_node_id, subject_id, transfer_priority));
             let message_session_id = MessageSessionId::from(as_u32);
 
             prop_assert_eq!(message_session_id.priority(), transfer_priority);

--- a/src/session_id/service.rs
+++ b/src/session_id/service.rs
@@ -23,12 +23,12 @@ pub struct ServiceSessionId {
 }
 
 impl ServiceSessionId {
-    pub fn request_as_u32(
+    pub fn request_from_base_parts(
         source_node_id: NodeId,
         destination_node_id: NodeId,
         service_id: ServiceId,
         priority: TransferPriority,
-    ) -> u32 {
+    ) -> Self {
         ServiceSessionId::new()
             .with_source_node_id(source_node_id)
             .with_destination_node_id(destination_node_id)
@@ -36,15 +36,14 @@ impl ServiceSessionId {
             .with_is_service(true)
             .with_is_request(true)
             .with_priority(priority)
-            .into()
     }
 
-    pub fn response_as_u32(
+    pub fn response_from_base_parts(
         source_node_id: NodeId,
         destination_node_id: NodeId,
         service_id: ServiceId,
         priority: TransferPriority,
-    ) -> u32 {
+    ) -> Self {
         ServiceSessionId::new()
             .with_source_node_id(source_node_id)
             .with_destination_node_id(destination_node_id)
@@ -52,7 +51,6 @@ impl ServiceSessionId {
             .with_is_service(true)
             .with_is_request(false)
             .with_priority(priority)
-            .into()
     }
 
     pub fn is_valid(&self) -> bool {
@@ -70,13 +68,13 @@ pub mod strategy {
 
     prop_compose! {
         pub fn request_session_id_as_u32()(source_node_id in node_id(), destination_node_id in node_id(), service_id in service_id(), transfer_priority in transfer_priority()) -> u32 {
-            ServiceSessionId::request_as_u32(source_node_id, destination_node_id, service_id, transfer_priority)
+            u32::from(ServiceSessionId::request_from_base_parts(source_node_id, destination_node_id, service_id, transfer_priority))
         }
     }
 
     prop_compose! {
         pub fn response_session_id_as_u32()(source_node_id in node_id(), destination_node_id in node_id(), service_id in service_id(), transfer_priority in transfer_priority()) -> u32 {
-            ServiceSessionId::response_as_u32(source_node_id, destination_node_id, service_id, transfer_priority)
+            u32::from(ServiceSessionId::response_from_base_parts(source_node_id, destination_node_id, service_id, transfer_priority))
         }
     }
 }
@@ -98,8 +96,8 @@ mod tests {
         #[test]
         fn a_service_session_id_has_its_27th_to_29th_bit_represent_the_transfer_priority(transfer_priority in transfer_priority()) {
             let (source_node_id, destination_node_id, service_id) = (NodeId::try_from(4).unwrap(), NodeId::try_from(7).unwrap(), ServiceId::try_from(10).unwrap());
-            let request_id = ServiceSessionId::request_as_u32(source_node_id, destination_node_id, service_id, transfer_priority);
-            let response_id = ServiceSessionId::response_as_u32(source_node_id, destination_node_id, service_id, transfer_priority);
+            let request_id = u32::from(ServiceSessionId::request_from_base_parts(source_node_id, destination_node_id, service_id, transfer_priority));
+            let response_id = u32::from(ServiceSessionId::response_from_base_parts(source_node_id, destination_node_id, service_id, transfer_priority));
 
             prop_assert_eq!(TransferPriority::try_from(((request_id >> 26) & 7)as u8).unwrap(), transfer_priority);
             prop_assert_eq!(TransferPriority::try_from(((response_id >> 26) & 7)as u8).unwrap(), transfer_priority);
@@ -140,8 +138,8 @@ mod tests {
         #[test]
         fn a_service_session_id_has_its_15th_to_23rd_bit_represent_the_service_id(service_id in service_id()) {
             let (source_node_id, destination_node_id, transfer_priority) = (NodeId::try_from(4).unwrap(), NodeId::try_from(7).unwrap(), TransferPriority::Immediate);
-            let request_id = ServiceSessionId::request_as_u32(source_node_id, destination_node_id, service_id, transfer_priority);
-            let response_id = ServiceSessionId::response_as_u32(source_node_id, destination_node_id, service_id, transfer_priority);
+            let request_id = u32::from(ServiceSessionId::request_from_base_parts(source_node_id, destination_node_id, service_id, transfer_priority));
+            let response_id = u32::from(ServiceSessionId::response_from_base_parts(source_node_id, destination_node_id, service_id, transfer_priority));
 
             prop_assert_eq!(ServiceId::try_from(((request_id >> 14) & 511)as u16).unwrap(), service_id);
             prop_assert_eq!(ServiceId::try_from(((response_id >> 14) & 511)as u16).unwrap(), service_id);
@@ -152,8 +150,8 @@ mod tests {
          #[test]
          fn a_service_session_id_has_its_8th_to_14th_bit_represent_the_service_id(destination_node_id in node_id()) {
              let (source_node_id, service_id, transfer_priority) = (NodeId::try_from(4).unwrap(), ServiceId::try_from(7).unwrap(), TransferPriority::Immediate);
-             let request_id = ServiceSessionId::request_as_u32(source_node_id, destination_node_id, service_id, transfer_priority);
-             let response_id = ServiceSessionId::response_as_u32(source_node_id, destination_node_id, service_id, transfer_priority);
+             let request_id = u32::from(ServiceSessionId::request_from_base_parts(source_node_id, destination_node_id, service_id, transfer_priority));
+             let response_id = u32::from(ServiceSessionId::response_from_base_parts(source_node_id, destination_node_id, service_id, transfer_priority));
 
              prop_assert_eq!(NodeId::try_from(((request_id >> 7) & 127)as u8).unwrap(), destination_node_id);
              prop_assert_eq!(NodeId::try_from(((response_id >> 7) & 127)as u8).unwrap(), destination_node_id);

--- a/src/session_id/session_kind.rs
+++ b/src/session_id/session_kind.rs
@@ -106,8 +106,8 @@ pub mod strategy {
                     subject_id,
                 }
             }),
-            request().prop_map(|request| SessionKind::Request(request)),
-            request().prop_map(|request| SessionKind::Response(request)),
+            request().prop_map(SessionKind::Request),
+            request().prop_map(SessionKind::Response),
         ]
     }
 

--- a/src/session_id/session_kind.rs
+++ b/src/session_id/session_kind.rs
@@ -66,27 +66,31 @@ pub fn can_id_for_session_kind(kind: SessionKind, priority: TransferPriority) ->
         SessionKind::Message {
             source_node_id,
             subject_id,
-        } => MessageSessionId::as_u32(source_node_id, subject_id, priority),
+        } => u32::from(MessageSessionId::from_base_parts(
+            source_node_id,
+            subject_id,
+            priority,
+        )),
         SessionKind::Request(Request {
             source_node_id,
             destination_node_id,
             service_id,
-        }) => ServiceSessionId::request_as_u32(
+        }) => u32::from(ServiceSessionId::request_from_base_parts(
             source_node_id,
             destination_node_id,
             service_id,
             priority,
-        ),
+        )),
         SessionKind::Response(Request {
             source_node_id,
             destination_node_id,
             service_id,
-        }) => ServiceSessionId::response_as_u32(
+        }) => u32::from(ServiceSessionId::response_from_base_parts(
             destination_node_id,
             source_node_id,
             service_id,
             priority,
-        ),
+        )),
     }
 }
 

--- a/src/tail_byte/tail_byte.rs
+++ b/src/tail_byte/tail_byte.rs
@@ -79,7 +79,7 @@ impl TailByte {
     // buildup as they currently need to advance manually before closing the
     // transfer.
     pub fn end_of_multi_transfer(&self) -> TailByte {
-        let mut byte = self.clone();
+        let mut byte = *self;
 
         // byte.set_toggle(byte.toggle() ^ 1);
         byte.set_is_start_of_transfer(false);

--- a/src/tail_byte/transfer_id.rs
+++ b/src/tail_byte/transfer_id.rs
@@ -93,7 +93,7 @@ mod tests {
             let successors = std::iter::successors(
                 Some((0u8, TransferId::try_from(x).unwrap())),
                 |(n, mut source)| { source.advance(); Some((n + 1, source))}
-            ).skip_while(|(_, source)| *source != target).next().unwrap().0;
+            ).find(|(_, source)| *source == target).unwrap().0;
 
             prop_assert_eq!(TransferId::try_from(x).unwrap().difference(target), successors);
         }

--- a/src/tx/breakdown.rs
+++ b/src/tx/breakdown.rs
@@ -181,7 +181,10 @@ impl<'a, Frame: CanFrame<MTU>, const MTU: usize> Breakdown<'a, Frame, MTU> {
     pub fn build_single_frame(&mut self) -> Frame {
         self.state = BreakdownState::Closed;
 
-        let payload = self.payload.next().unwrap_or(self.payload.remainder());
+        let payload = self
+            .payload
+            .next()
+            .unwrap_or_else(|| self.payload.remainder());
         build_frame(self.can_id, payload, self.tail_byte)
     }
 


### PR DESCRIPTION
Resolves #55.

- `clippy::module_inception` warns when a module has the same name as its
containing module.
    
    For this library this happens in a few places.
    For example, the top-level module directory `tail_byte` has a `tail_byte.rs`
    file inside.
    
    The style for this library dictates that, generally, the `mod.rs` files are used
    principally to export the final interface, which is not yet done for each module
    but will be in the future, while each small or central type gets its own file.
    
    In this case, the top-level `tail_byte` module represents the `tail-byte`
    concept from uavcan, while the internal `tail_byte` module from `tail_byte.rs`
    represents the specific type that is used for the `tail_byte`.
    
    This convention is in contrast with clippy defaults warns.
    
    Since the library takes a standing that this is a cleaner solution,
    `clippy::module_inception` was moved from `warn` to `allow`.

- A few types provided new constructors that took no arguments.

    The clippy warn `new_without_default` catches those type of code construct to
    favor the more specific `Default` instead of naked news.
    
    To comply with this sensible lint, the codebase was modified to avoid naked news
    and use `Default` instead.

- The clippy lint `or_fun_call` warns when the non-lazy version of the branching
chain-operators is used with a function call instead of the lazy version
`*or_else`.

    Using the lazy version can slightly improve performance and avoid the case where
    a side-effect is executed when it shouldn't.
    
    For this reason, the codebase was modified to comply with the lint.
    
- As found trough clippy's `needless_lifetime` lint, rust is able to infer the
lifetime of such a call automatically, making it needless to specify it as a
parameter.

    To comply with the lint and simplify the code, the lifetime generic parameter
    was removed.

- Clippy's `redundant_closures` warns when a closure is created to wrap a function
call that has the same signature as the closure and can, hence, be called
directly by reference.

    To comply with the lint and lighten the code, the codebase was modified to
    remove the wrapping closures from those type of calls.

- The custom fork was initially made as a temporary solution to the warning
problem in `modular_bitfield` while we waited for upstream PRs to be merged.

    Since the `modular_bitfield` repository is moving slowly and other
    warning-related problems have come up, the custom fork is now considered
    permanent to allow for moving along with the issues.
    
    For this reasons, the work on the custom fork was merged into its master branch
    and the dependency in `uavcan` was modified to not use a custom branch anymore.
    
    The latest changes in `modular_bitfield` further resolves the problem with
    clippy's `identity_op` warning in autogenerated `From` implementations.

- The various `*as_u32` methods in `MessageSessionId` and `ServiceSessionId`,
where used to build the types from the other base types provided by the crate,
such as `TransferPriority`, and then to convert them to a `u32`, to be used in
places where the numeral representation was needed as a `can_id`.

    In the specific case of `MessageSessionId::as_u32`, the naming clashed with
    `clippy::wrong_self_convention`, as it started with `as` but took no self.
    
    The naming was a workaround as `new` is unavailable for `modular_bitfield`
    generated crate, conflicting with the autogenerated implementation.
    
    To support both the `modular_bitfield` requirement and the clippy sensible lint,
    the method was renamed to `from_base_parts`, to identify a construction of an
    instance from the small, changing, parts that composes it.
    
    Furthermore, to better align the method with a "constructor" feeling, the return
    type was changed to `Self` and the conversion to `u32` was delegated to the user
    of the method, which can use the autogenerated `From` implementation to obtain
    the required representation.
    
    All the places that previously used the method were updated with the new naming
    and by surrounding the call in a `u32::from` expression.
    
    To keep consistency, `ServiceSessionId::request_as_u32` and
    `ServiceSessionId::response_as_u32` were modified to follow the same naming
    convention and their call locations were updated accordingly.

- Removes clones on Copy types.
- Simplifies skip_while(...).next into find.
- Removes unnecessary unit return types from the hello_can example.
- Removes unnecessary lifetimes from the hello_can example.
- The `hello_can` example function `process` consumes all available transfer, if
any, before returning.

    This was done with a `while let Some(...) = iterator.next()`.
    As clippy's `while_let_on_iterator` sensibly points out, this is equivalent to a for loop on the iterator,
    as it already takes care of stopping when `None` is encountered.
    
    For this reason, the `while let` construct was modified to a simpler `for` construct.
