### PR TITLE
Issue 28/adding a continuos integration workflow for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        architecture: [x86_64-unknown-linux-gnu, thumbv7em-none-eabihf]
+        architecture: [x86_64-unknown-linux-gnu, thumbv7em-none-eabihf, thumbv6m-none-eabi]
         target: [--all-targets, --lib]
         exclude:
           - target: --all-targets
-            architecture: thumbv7em-none-eabihf
+            architecture: [thumbv7em-none-eabihf, thumbv6m-none-eabi]
           - target: --lib
             architecture: x86_64-unknown-linux-gnu
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           toolchain: nightly
           override: true
-      - uses: actions-rs/taurpalin@v1
+      - uses: actions-rs/tarpaulin@v1
       - uses: codecov/codecov-action@v1
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           toolchain: nightly
           override: true
-      - uses: actions-rs/tarpaulin@v1
+      - uses: actions-rs/tarpaulin@v0.1
       - uses: codecov/codecov-action@v1
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,17 +8,21 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: Build-${{ matrix.architecture }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        architecture: [x86_64-unknown-linux-gnu, thumbv7em-none-eabihf]
+        target: [--all-targets, --lib]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           override: true
-          target: x86_64-unknown-linux-gnu
+          target: ${{ matrix.architecture }}
       - uses: actions-rs/cargo@v1
         with:
           command: build
           use-cross: true
-          args: --all-targets
+          args: ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
         target: [--all-targets, --lib]
         exclude:
           - target: --all-targets
-            architecture: [thumbv7em-none-eabihf, thumbv6m-none-eabi]
+            architecture: thumbv7em-none-eabihf
+          - target: --all-targets
+            architecture: thumbv6m-none-eabi
           - target: --lib
             architecture: x86_64-unknown-linux-gnu
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,20 @@ jobs:
         with:
           name: code-coverage-report
           path: cobertura.xml
+  rustfmt:
+    name: Rust Format
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          components: rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: Continuos Integration
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  placeholder:
+    name: Placeholder
+    runs-on: ubuntu-latest
+    run: echo PLACEHOLDER
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,17 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-targets
-
-
-
+  documentation:
+    name: Documentation Generation
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: rustdoc
+          args: -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,5 +65,21 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+  clippy:
+    name: Rust Clippy
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          components: clippy
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-targets
+
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,18 @@ jobs:
           command: build
           use-cross: true
           args: ${{ matrix.target }} --target ${{ matrix.architecture }}
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - uses: actions-rs/taurpalin@v1
+      - uses: codecov/codecov-action@v1
+      - uses: actions/upload-artifact@v2
+        with:
+          name: code-coverage-report
+          path: cobertura.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ jobs:
       matrix:
         architecture: [x86_64-unknown-linux-gnu, thumbv7em-none-eabihf]
         target: [--all-targets, --lib]
+        exclude:
+          - target: --all-targets
+            architecture: thumbv7em-none-eabihf
+          -target: --lib
+            architecture: x86_64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         exclude:
           - target: --all-targets
             architecture: thumbv7em-none-eabihf
-          -target: --lib
+          - target: --lib
             architecture: x86_64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,11 @@ jobs:
           command: build
           use-cross: true
           args: ${{ matrix.target }} --target ${{ matrix.architecture }}
+      - uses: Swatinem/rust-cache@v1
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
         with:
           command: build
           use-cross: true
-          args: ${{ matrix.target }}
+          args: ${{ matrix.target }} --target ${{ matrix.architecture }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,18 @@ on:
     branches: [ main ]
 
 jobs:
-  placeholder:
-    name: Placeholder
+  build:
+    name: Build
     runs-on: ubuntu-latest
-    run: echo PLACEHOLDER
-
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          target: x86_64-unknown-linux-gnu
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          use-cross: true
+          args: --all-targets


### PR DESCRIPTION
Resolves #28.

Adds a Continuous Integration pipeline for the project trought Github Actions workflows.

The workflow runs automatically when a pull request is made or commited to and when a pull request or some other changes is pushed to main.
The project uses a `Pull Request` approach for any change such that the first hook ensures that a minimum quality for the code is respected.
The second hook ensures that the end result of main is always stable. This is mostly redundant when everything passes trough PRs, but was considered required as to avoid any possible breakage of main.

The workflow runs a series of checks:

- It checks that the project can be built for both x86_64 linux and for embedded devices. 
  As per the way the library built, the linux targets builds all parts of the crates ( tests, examples and so on ) and the embedded targets only build the library, as that is the only part of the crate that does not make any use of `std`. 
- Runs the automated tests on an `std`-compatible target and ensures that no test is currently failing.
  
   Furthermore, code-coverage reports are generated trough `cargo tarpaulin` and added as an artifact to the repository.
   Integration with `codecov` ensures that the changes in coverage between PRs is registered and analyzed. 
- It checks that the code is formatted according to `rustfmt`.
- It checks that no error is returned from clippy.
- It checks that the documentation builds correctly and no reference in it is unresolvable.
  