### PR TITLE
Issue 59/handling zero length frames

### DIFF
--- a/src/tx/breakdown.rs
+++ b/src/tx/breakdown.rs
@@ -1,6 +1,3 @@
-// TODO: Remember to deal with the fact that a 0 payload is unacceptable. Might
-// be better to deal with this outside breakdown.
-
 // TODO: A general refactoring of this must be done. Previously a
 // misunderstanding made it so that we expected the CRC to always be on its
 // frame even when enough space for it was available. This is now changed but


### PR DESCRIPTION
Resolves #59.

- `Buildup` assumes that at least 1 byte of payload is present in each frame.

  Indeed, a zero-bytes payload is not a uavcan frame as at least the tail-byte
  must be present, even when the payload data is empty.

  Before this commit, no check was done on the payload of a frame before it was
  sent to `Buildup`, this produced, a panic, due to an underflow, when
  `Buildup` tried to split the tail-byte from the payload.

  To avoid this panic, receive is now modified to check the length of the frame's
  payload and rise an error if it is zero.

  A test was added to ensure that this is the case.
- The uavcan specification section 4.1.1.1 says that:

   ```
   A transfer carries **zero** or more bytes of transfer payload
   ```

   To ensure that this specification is respected, tests were added to ensure that
   a zero data payload was handled by `Breakdown`.
- An old TODO about this issue was removed.